### PR TITLE
Add Supabase-native clinic backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Thumbs.db
 out
 
 .env
+
+# Supabase CLI metadata
+supabase/.temp/

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,4 @@
+# Public values are safe to expose to the browser. Row Level Security protects
+# clinic data; never put a Supabase service-role key in a NEXT_PUBLIC variable.
+NEXT_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<supabase-anon-key>

--- a/apps/web/src/components/create-exposure/use-create-exposure-form.ts
+++ b/apps/web/src/components/create-exposure/use-create-exposure-form.ts
@@ -13,8 +13,7 @@ import { useCreateExposure } from '@/hooks/mutations/use-exposure-mutations';
 import { NewExposure } from '@/types/exposure';
 import { AppRoutes } from '@/constants/routes';
 import { capitalizeFields } from '@/utils/string-utils';
-import { Configuration, SchedulesApi } from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
+import { createVaccinationSchedule } from '@/utils/schedules';
 import { useToast } from '@/hooks/use-toast';
 
 const exposureStepFields = [
@@ -166,34 +165,9 @@ export function useCreateExposureForm(patientId: string) {
         throw new Error('Failed to create exposure');
       }
 
-      // Step 2: Create schedule for the exposure
-      const { session } = await getSession();
-      const accessToken = session?.access_token;
-
-      if (!accessToken) {
-        throw new Error('No authentication token found');
-      }
-
-      const config = new Configuration({
-        basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-        accessToken: accessToken,
-      });
-
-      const schedulesApi = new SchedulesApi(config);
-      const createScheduleDto: {
-        exposureId?: string;
-        startDate?: string;
-      } = {
-        exposureId: createdExposureId,
-      };
-
-      // Use dateOfExposure as start date
-      if (data.dateOfExposure) {
-        createScheduleDto.startDate = data.dateOfExposure.toISOString();
-      }
-
-      const scheduleResponse = await schedulesApi.schedulesControllerCreate(
-        createScheduleDto
+      const schedule = await createVaccinationSchedule(
+        createdExposureId,
+        data.dateOfExposure?.toISOString()
       );
 
       toast({
@@ -205,7 +179,7 @@ export function useCreateExposureForm(patientId: string) {
       router.push(
         AppRoutes.EDIT_PATIENT.replace(':id', patientId).replace(
           ':scheduleId',
-          scheduleResponse.data.id
+          schedule.id
         )
       );
     } catch (error: any) {

--- a/apps/web/src/components/dialog/create-schedule.tsx
+++ b/apps/web/src/components/dialog/create-schedule.tsx
@@ -13,8 +13,7 @@ import { Button } from '../ui/button';
 import { Label } from '../ui/label';
 import { Loader2, Calendar, AlertCircle } from 'lucide-react';
 import CustomDatePicker from '@/components/custom-fields/custom-date-picker';
-import { Configuration, SchedulesApi } from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
+import { createVaccinationSchedule } from '@/utils/schedules';
 import { useToast } from '@/hooks/use-toast';
 import { useRouter } from 'next/navigation';
 import { AppRoutes } from '@/constants/routes';
@@ -161,36 +160,9 @@ export default function CreateScheduleDialog({
 
       const createdExposureId = exposureResponse.data.id;
 
-      // Step 2: Create schedule for the exposure
-      const { session } = await getSession();
-      const accessToken = session?.access_token;
-
-      if (!accessToken) {
-        throw new Error('No authentication token found. Please log in again.');
-      }
-
-      const config = new Configuration({
-        basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-        accessToken: accessToken,
-      });
-
-      const schedulesApi = new SchedulesApi(config);
-      const createScheduleDto: {
-        exposureId?: string;
-        startDate?: string;
-      } = {
-        exposureId: createdExposureId,
-      };
-
-      // Use startDate if provided, otherwise use dateOfExposure
-      if (startDate) {
-        createScheduleDto.startDate = startDate.toISOString();
-      } else if (formData.dateOfExposure) {
-        createScheduleDto.startDate = formData.dateOfExposure.toISOString();
-      }
-
-      const scheduleResponse = await schedulesApi.schedulesControllerCreate(
-        createScheduleDto
+      const schedule = await createVaccinationSchedule(
+        createdExposureId,
+        startDate?.toISOString() || formData.dateOfExposure?.toISOString()
       );
 
       toast({
@@ -213,7 +185,7 @@ export default function CreateScheduleDialog({
       router.push(
         AppRoutes.EDIT_PATIENT.replace(':id', patientId).replace(
           ':scheduleId',
-          scheduleResponse.data.id
+          schedule.id
         )
       );
     } catch (error: any) {

--- a/apps/web/src/components/patient-registration/use-patient-form.ts
+++ b/apps/web/src/components/patient-registration/use-patient-form.ts
@@ -12,8 +12,7 @@ import { NewPatient } from '@/types/patient';
 import { NewExposure } from '@/types/exposure';
 import { AppRoutes } from '@/constants/routes';
 import { capitalizeFields } from '@/utils/string-utils';
-import { Configuration, SchedulesApi } from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
+import { createVaccinationSchedule } from '@/utils/schedules';
 
 // Helper to convert form data to NewPatient format (metadata only)
 const formatPatientData = (data: FormValues): NewPatient => {
@@ -175,23 +174,7 @@ export function usePatientForm() {
         throw new Error('Failed to create exposure');
       }
 
-      // Step 3: Create schedule
-      const { session } = await getSession();
-      const accessToken = session?.access_token;
-
-      if (!accessToken) {
-        throw new Error('No authentication token found');
-      }
-
-      const config = new Configuration({
-        basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-        accessToken: accessToken,
-      });
-
-      const schedulesApi = new SchedulesApi(config);
-      await schedulesApi.schedulesControllerCreate({
-        exposureId: createdExposureId,
-      });
+      await createVaccinationSchedule(createdExposureId);
 
       // Navigate to patient schedules page
       router.push(AppRoutes.PATIENT_SCHEDULES.replace(':id', createdPatientId));

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { getSession } from '@/lib/auth/client';
 import type { User as SupabaseUser } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/client';
 
 interface User {
   id: string | null;
@@ -124,20 +125,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     };
 
-    const fetchUserFromBackend = async (accessToken: string) => {
+    const fetchUserFromSupabase = async (userId: string) => {
       try {
-        const { Configuration, UsersApi } = await import('@abc-admin/api-lib');
-        const config = new Configuration({
-          basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-          accessToken: accessToken,
-        });
-        const usersApi = new UsersApi(config);
-        const response = await usersApi.usersControllerGetMe();
-        const userData = response.data as any;
-
-        return userData;
+        const { data, error } = await createClient()
+          .from('users')
+          .select('id, email, role')
+          .eq('id', userId)
+          .single();
+        return error ? null : data;
       } catch (error) {
-        console.error('Error fetching user from backend:', error);
+        console.error('Error fetching user from Supabase:', error);
         return null;
       }
     };
@@ -151,11 +148,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setSupabaseUser(session.user);
         setAccessToken(session.access_token);
 
-        // Provision an invited user before accessing any protected API endpoint.
+        // Provision an invited user before querying protected Supabase tables.
         await consumePendingInviteCode();
 
-        // Call /me endpoint to fetch the local user and role.
-        const userData = await fetchUserFromBackend(session.access_token);
+        const userData = await fetchUserFromSupabase(session.user.id);
         if (userData) {
           setUser({
             id: userData.id,

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -1,0 +1,21 @@
+import { createBrowserClient } from '@supabase/ssr';
+
+let client: ReturnType<typeof createBrowserClient> | undefined;
+
+export function createClient() {
+  if (client) {
+    return client;
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    throw new Error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY'
+    );
+  }
+
+  client = createBrowserClient(url, key);
+  return client;
+}

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -6,8 +6,10 @@ export async function updateSession(request: NextRequest) {
     request,
   });
 
-  const supabaseUrl = process.env.SUPABASE_URL;
-  const supabaseKey = process.env.SUPABASE_ANON_KEY;
+  const supabaseUrl =
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const supabaseKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 
   // During build time, env vars might not be available - just pass through
   if (!supabaseUrl || !supabaseKey) {

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -4,12 +4,14 @@ import { cookies } from 'next/headers';
 export async function createClient() {
   const cookieStore = await cookies();
 
-  const supabaseUrl = process.env.SUPABASE_URL;
-  const supabaseKey = process.env.SUPABASE_ANON_KEY;
+  const supabaseUrl =
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const supabaseKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
-      'Missing Supabase environment variables: SUPABASE_URL and SUPABASE_ANON_KEY are required'
+      'Missing Supabase environment variables: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are required'
     );
   }
 

--- a/apps/web/src/utils/add-exposure.ts
+++ b/apps/web/src/utils/add-exposure.ts
@@ -1,107 +1,30 @@
-import {
-  ExposuresApi,
-  Configuration,
-  CreateExposureDto,
-} from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
-import { NewExposure, Exposure } from '@/types/exposure';
-
-interface ApiResponse<T> {
-  data: T;
-  status: number;
-  statusText: string;
-  headers: Record<string, string>;
-  config: any;
-  request: any;
-}
-
-export class ApiError extends Error {
-  status?: number;
-
-  constructor(message: string, status?: number) {
-    super(message);
-    this.name = 'ApiError';
-    this.status = status;
-  }
-}
+import { Exposure, NewExposure } from '@/types/exposure';
+import { ApiResponse } from './add-patient';
+import { getSupabaseClient, response, throwOnSupabaseError } from './supabase';
 
 export const addExposure = async (
   newExposure: NewExposure
 ): Promise<ApiResponse<Exposure>> => {
-  const { session } = await getSession();
-  const accessToken = session?.access_token;
-
-  if (!accessToken) {
-    throw new ApiError(
-      'No authentication token found. Please log in again.',
-      401
-    );
-  }
-
-  const config = new Configuration({
-    basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    accessToken: accessToken,
-  });
-
-  try {
-    // Adapt NewExposure to CreateExposureDto format expected by API
-    const createExposureDto: CreateExposureDto = {
+  const { data, error } = await getSupabaseClient()
+    .from('exposures')
+    .insert({
       patientId: newExposure.patientId,
-      category: newExposure.category as any, // API expects object (enum), but we have number
+      category: newExposure.category,
       bodyPartsAffected: newExposure.bodyPartsAffected,
       placeOfExposure: newExposure.placeOfExposure,
       dateOfExposure: newExposure.dateOfExposure,
       isExposureAtHome: newExposure.isExposureAtHome,
       sourceOfExposure: newExposure.sourceOfExposure,
-      animalStatus: newExposure.animalStatus as any, // API expects object (enum)
+      animalStatus: newExposure.animalStatus || 'unknown',
       isWoundCleaned: newExposure.isWoundCleaned,
       antiTetanusGiven: newExposure.antiTetanusGiven,
+      dateOfAntiTetanus: newExposure.dateOfAntiTetanus || null,
       briefHistory: newExposure.briefHistory,
       allergy: newExposure.allergy,
       medications: newExposure.medications,
-      // Only include dateOfAntiTetanus if provided
-      ...(newExposure.dateOfAntiTetanus && {
-        dateOfAntiTetanus: newExposure.dateOfAntiTetanus,
-      }),
-    } as CreateExposureDto;
-
-    const exposuresApi = new ExposuresApi(config);
-    const response = await exposuresApi.exposuresControllerCreate(
-      createExposureDto
-    );
-
-    return response as unknown as ApiResponse<Exposure>;
-  } catch (error: any) {
-    console.error('API connection failed:', error);
-
-    // Check for specific API error responses
-    if (error.response) {
-      const status = error.response.status;
-      const errorMessage = error.response.data?.message;
-      let message = 'An error occurred while adding the exposure';
-
-      // Handle specific status codes
-      if (status === 409) {
-        message =
-          'An exposure already exists. Please use the existing exposure or contact support.';
-      } else if (status === 400) {
-        message =
-          errorMessage ||
-          'Invalid input data. Please check your form and try again.';
-      } else if (status === 401 || status === 403) {
-        message = 'You are not authorized to perform this action.';
-      } else if (status === 404) {
-        message = 'Patient not found.';
-      } else if (status >= 500) {
-        message = 'Server error. Please try again later.';
-      }
-
-      throw new ApiError(message, status);
-    }
-
-    // For other errors
-    throw new ApiError(
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
-  }
+    })
+    .select()
+    .single();
+  throwOnSupabaseError(error, 'Failed to create exposure');
+  return response(data as Exposure);
 };

--- a/apps/web/src/utils/add-patient.ts
+++ b/apps/web/src/utils/add-patient.ts
@@ -1,93 +1,34 @@
-import { PatientsApi, Configuration } from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
 import { NewPatient, Patient } from '@/types/patient';
-import { Sex } from '@abc-admin/enums';
+import { getSupabaseClient, response, throwOnSupabaseError } from './supabase';
 
-interface ApiResponse<T> {
+export { ApiError } from './supabase';
+
+export interface ApiResponse<T> {
   data: T;
   status: number;
   statusText: string;
   headers: Record<string, string>;
-  config: any;
-  request: any;
+  config: Record<string, never>;
+  request: Record<string, never>;
 }
-
-export class ApiError extends Error {
-  status?: number;
-
-  constructor(message: string, status?: number) {
-    super(message);
-    this.name = 'ApiError';
-    this.status = status;
-  }
-}
-
-// Adapter function to convert NewPatient to CreatePatientDto
-const adaptToCreatePatientDto = (patient: NewPatient): any => {
-  // Create the base object with only patient metadata fields
-  const adaptedPatient = {
-    firstName: patient.firstName,
-    middleName: patient.middleName || '',
-    lastName: patient.lastName,
-    dateOfBirth: patient.dateOfBirth,
-    sex: patient.sex as Sex,
-    address: patient.address,
-    email: patient.email || '',
-  };
-
-  return adaptedPatient;
-};
 
 export const addPatient = async (
   newPatient: NewPatient
 ): Promise<ApiResponse<Patient>> => {
-  const { session } = await getSession();
-  const accessToken = session?.access_token;
+  const { data, error } = await getSupabaseClient()
+    .from('patients')
+    .insert({
+      firstName: newPatient.firstName,
+      middleName: newPatient.middleName || null,
+      lastName: newPatient.lastName,
+      dateOfBirth: newPatient.dateOfBirth,
+      sex: newPatient.sex,
+      address: newPatient.address,
+      email: newPatient.email || null,
+    })
+    .select()
+    .single();
 
-  if (!accessToken) {
-    throw new ApiError(
-      'No authentication token found. Please log in again.',
-      401
-    );
-  }
-
-  const config = new Configuration({
-    basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    accessToken: accessToken,
-  });
-
-  try {
-    const patientsApi = new PatientsApi(config);
-    const response = await patientsApi.patientsControllerCreate(
-      adaptToCreatePatientDto(newPatient)
-    );
-    return response as unknown as ApiResponse<Patient>;
-  } catch (error: any) {
-    console.error('API connection failed:', error);
-
-    // Check for specific API error responses
-    if (error.response) {
-      const status = error.response.status;
-      let message = 'An error occurred while adding the patient';
-
-      // Handle specific status codes
-      if (status === 409) {
-        message =
-          'This email is already registered. Please use a different email address.';
-      } else if (status === 400) {
-        message = 'Invalid input data. Please check your form and try again.';
-      } else if (status === 401 || status === 403) {
-        message = 'You are not authorized to perform this action.';
-      } else if (status >= 500) {
-        message = 'Server error. Please try again later.';
-      }
-
-      throw new ApiError(message, status);
-    }
-
-    // For other errors
-    throw new ApiError(
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
-  }
+  throwOnSupabaseError(error, 'Failed to create patient');
+  return response(data as Patient);
 };

--- a/apps/web/src/utils/auth.ts
+++ b/apps/web/src/utils/auth.ts
@@ -1,4 +1,4 @@
-import { AuthApi, Configuration } from '@abc-admin/api-lib';
+import { createClient } from '@/lib/supabase/client';
 
 interface UserProfile {
   id: string;
@@ -7,24 +7,23 @@ interface UserProfile {
 }
 
 export async function getCurrentUser(): Promise<UserProfile | null> {
-  try {
-    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080';
-    
-    const configuration = new Configuration({
-      basePath: backendUrl,
-      baseOptions: {
-        withCredentials: true
-      }
-    });
-    
-    const authApi = new AuthApi(configuration);
-    const response = await authApi.authControllerGetProfile();
-    
-    return response.data as unknown as UserProfile;
-  } catch (error) {
-    console.error('Failed to get user profile:', error);
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
     return null;
   }
+
+  const { data, error } = await supabase
+    .from('users')
+    .select('id, email, role')
+    .eq('id', user.id)
+    .single();
+  if (error || !data) {
+    return null;
+  }
+  return data as UserProfile;
 }
 
 export function isAdmin(userRole: string | null): boolean {
@@ -32,20 +31,8 @@ export function isAdmin(userRole: string | null): boolean {
 }
 
 export async function verifyAuthentication(): Promise<boolean> {
-  try {
-    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080';
-    
-    const configuration = new Configuration({
-      basePath: backendUrl,
-      baseOptions: {
-        withCredentials: true
-      }
-    });
-    
-    const authApi = new AuthApi(configuration);
-    await authApi.authControllerVerifyToken();
-    return true;
-  } catch (error) {
-    return false;
-  }
-} 
+  const {
+    data: { user },
+  } = await createClient().auth.getUser();
+  return Boolean(user);
+}

--- a/apps/web/src/utils/get-patient-schedules.ts
+++ b/apps/web/src/utils/get-patient-schedules.ts
@@ -1,55 +1,45 @@
-import { Configuration, SchedulesApi } from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
+import { Exposure } from '@/types/exposure';
 import { Schedule } from '@/types/schedule';
-import { ScheduleStatus } from '@/enums/schedule-status';
-import { ApiError } from './add-patient';
+import { getSupabaseClient, throwOnSupabaseError } from './supabase';
+
+function formatSchedule(
+  schedule: Record<string, unknown>,
+  exposure: Exposure
+): Schedule {
+  return {
+    ...schedule,
+    exposureId: exposure.id,
+    patientId: exposure.patientId,
+    exposure,
+  } as Schedule;
+}
 
 export const getPatientSchedules = async (
   patientId: string
 ): Promise<Schedule[]> => {
-  const { session } = await getSession();
-  const accessToken = session?.access_token;
+  const supabase = getSupabaseClient();
+  const { data: exposures, error: exposureError } = await supabase
+    .from('exposures')
+    .select('*')
+    .eq('patientId', patientId)
+    .order('createdAt', { ascending: false });
+  throwOnSupabaseError(exposureError, 'Failed to fetch patient exposures');
 
-  if (!accessToken) {
-    throw new ApiError(
-      'No authentication token found. Please log in again.',
-      401
-    );
+  if (!exposures?.length) {
+    return [];
   }
 
-  const config = new Configuration({
-    basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    accessToken: accessToken,
-  });
-
-  const schedulesApi = new SchedulesApi(config);
-  const response = await schedulesApi.schedulesControllerFindAllByPatientId(
-    patientId
+  const exposureById = new Map(
+    exposures.map((exposure) => [exposure.id, exposure as Exposure])
   );
+  const { data: schedules, error } = await supabase
+    .from('schedules')
+    .select('*')
+    .in('exposureId', exposures.map((exposure) => exposure.id))
+    .order('createdAt', { ascending: false });
+  throwOnSupabaseError(error, 'Failed to fetch schedules');
 
-  return (response.data as any[]).map((schedule: any) => {
-    const {
-      day0CompletedAt,
-      day3CompletedAt,
-      day7CompletedAt,
-      day28CompletedAt,
-      exposure,
-      ...rest
-    } = schedule;
-
-    return {
-      ...rest,
-      exposureId: exposure?.id,
-      patientId: exposure?.patient?.id || patientId,
-      exposure: exposure,
-      status:
-        schedule.status === ScheduleStatus.completed
-          ? ScheduleStatus.completed
-          : ScheduleStatus.in_progress,
-      day0CompletedAt: day0CompletedAt || undefined,
-      day3CompletedAt: day3CompletedAt || undefined,
-      day7CompletedAt: day7CompletedAt || undefined,
-      day28CompletedAt: day28CompletedAt || undefined,
-    };
-  });
+  return (schedules || []).map((schedule) =>
+    formatSchedule(schedule, exposureById.get(schedule.exposureId)!)
+  );
 };

--- a/apps/web/src/utils/get-patients.ts
+++ b/apps/web/src/utils/get-patients.ts
@@ -1,64 +1,31 @@
-import { Configuration, PatientsApi } from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
 import { Patient, PatientSummary } from '@/types/patient';
-import { ApiError } from './add-patient';
+import { ApiError, getSupabaseClient, throwOnSupabaseError } from './supabase';
 
 export const getPatients = async (
   page: number
-): Promise<{
-  patients: Patient[];
-  total: number;
-}> => {
-  const { session } = await getSession();
-  const accessToken = session?.access_token;
+): Promise<{ patients: Patient[]; total: number }> => {
+  const { data, error } = await getSupabaseClient().rpc(
+    'list_patient_summaries',
+    { p_page: page, p_page_size: 10 }
+  );
+  throwOnSupabaseError(error, 'Failed to fetch patients');
 
-  if (!accessToken) {
-    throw new ApiError(
-      'No authentication token found. Please log in again.',
-      401
-    );
-  }
-
-  const config = new Configuration({
-    basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    accessToken: accessToken,
-  });
-
-  const patientsApi = new PatientsApi(config);
-  const response = await patientsApi.patientsControllerFindAll(page);
-  const typedResponse = response.data as unknown as {
-    patients: Patient[];
-    total: number;
+  const result = data as { patients?: Patient[]; total?: number } | null;
+  return {
+    patients: result?.patients || [],
+    total: result?.total || 0,
   };
-
-  return typedResponse;
 };
 
 export const getPatientSummary = async (
   patientId: string
 ): Promise<{ patient: PatientSummary | null }> => {
-  const { session } = await getSession();
-  const accessToken = session?.access_token;
-
-  if (!accessToken) {
-    throw new ApiError(
-      'No authentication token found. Please log in again.',
-      401
-    );
-  }
-
-  const config = new Configuration({
-    basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    accessToken: accessToken,
+  const { data, error } = await getSupabaseClient().rpc('patient_summary', {
+    p_patient_id: patientId,
   });
-
-  const patientsApi = new PatientsApi(config);
-  const response = await patientsApi.patientsControllerFindOneAsSummary(
-    patientId
-  );
-  const typedResponse = response.data as unknown as {
-    patient: PatientSummary;
-  };
-
-  return typedResponse;
+  throwOnSupabaseError(error, 'Failed to fetch patient summary');
+  if (!data) {
+    throw new ApiError('Patient not found', 404);
+  }
+  return { patient: data as PatientSummary };
 };

--- a/apps/web/src/utils/get-schedule.ts
+++ b/apps/web/src/utils/get-schedule.ts
@@ -1,66 +1,39 @@
-import { Configuration, SchedulesApi } from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
+import { Exposure } from '@/types/exposure';
 import { Schedule } from '@/types/schedule';
-import { ScheduleStatus } from '@/enums/schedule-status';
-import { ApiError } from './add-patient';
+import { getPatientSchedules } from './get-patient-schedules';
+import { ApiError, getSupabaseClient, throwOnSupabaseError } from './supabase';
 
 export const getSchedule = async (
   patientId: string,
   scheduleId?: string
 ): Promise<Schedule> => {
-  const { session } = await getSession();
-  const accessToken = session?.access_token;
-
-  if (!accessToken) {
-    throw new ApiError(
-      'No authentication token found. Please log in again.',
-      401
-    );
-  }
-
-  const config = new Configuration({
-    basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    accessToken: accessToken,
-  });
-
-  const schedulesApi = new SchedulesApi(config);
-
-  let response;
-  if (scheduleId) {
-    // Fetch by schedule ID
-    response = await schedulesApi.schedulesControllerFindOne(scheduleId);
-  } else {
-    // Fetch by patient ID (returns most recent schedule for backward compatibility)
-    const schedulesResponse =
-      await schedulesApi.schedulesControllerFindAllByPatientId(patientId);
-    if (!schedulesResponse.data || schedulesResponse.data.length === 0) {
+  if (!scheduleId) {
+    const schedules = await getPatientSchedules(patientId);
+    if (!schedules.length) {
       throw new ApiError('No schedule found for patient', 404);
     }
-    // Use the first schedule (most recent)
-    response = { data: schedulesResponse.data[0] };
+    return schedules[0];
   }
 
-  const {
-    day0CompletedAt,
-    day3CompletedAt,
-    day7CompletedAt,
-    day28CompletedAt,
-    exposure,
-    ...rest
-  } = response.data as any;
+  const supabase = getSupabaseClient();
+  const { data: schedule, error } = await supabase
+    .from('schedules')
+    .select('*')
+    .eq('id', scheduleId)
+    .single();
+  throwOnSupabaseError(error, 'Schedule not found');
+
+  const { data: exposure, error: exposureError } = await supabase
+    .from('exposures')
+    .select('*')
+    .eq('id', schedule.exposureId)
+    .single();
+  throwOnSupabaseError(exposureError, 'Exposure not found');
 
   return {
-    ...rest,
-    exposureId: exposure?.id,
-    patientId: exposure?.patient?.id || patientId,
-    exposure: exposure,
-    status:
-      response.data.status === ScheduleStatus.completed
-        ? ScheduleStatus.completed
-        : ScheduleStatus.in_progress,
-    day0CompletedAt: day0CompletedAt || undefined,
-    day3CompletedAt: day3CompletedAt || undefined,
-    day7CompletedAt: day7CompletedAt || undefined,
-    day28CompletedAt: day28CompletedAt || undefined,
+    ...(schedule as Schedule),
+    exposureId: exposure.id,
+    patientId: exposure.patientId,
+    exposure: exposure as Exposure,
   };
 };

--- a/apps/web/src/utils/get-users.ts
+++ b/apps/web/src/utils/get-users.ts
@@ -1,25 +1,18 @@
-import { UsersApi, Configuration } from '@abc-admin/api-lib';
 import { Admin } from '@/types/admin';
-import { getSession } from '@/lib/auth/client';
-import { ApiError } from './add-patient';
+import { getSupabaseClient, throwOnSupabaseError } from './supabase';
 
 export const getUsers = async (): Promise<Admin[]> => {
-  const { session } = await getSession();
-  const accessToken = session?.access_token;
+  const { data, error } = await getSupabaseClient()
+    .from('users')
+    .select('id, email, role, isActive')
+    .order('createdAt', { ascending: false });
+  throwOnSupabaseError(error, 'Failed to fetch administrators');
 
-  if (!accessToken) {
-    throw new ApiError(
-      'No authentication token found. Please log in again.',
-      401
-    );
-  }
-
-  const config = new Configuration({
-    basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    accessToken: accessToken,
-  });
-
-  const usersApi = new UsersApi(config);
-  const response = await usersApi.usersControllerFindAll();
-  return (response as unknown as { data: Admin[] }).data;
+  return (data || []).map((user) => ({
+    id: user.id,
+    username: '',
+    email: user.email,
+    role: user.role,
+    isActive: user.isActive,
+  }));
 };

--- a/apps/web/src/utils/invite-codes.ts
+++ b/apps/web/src/utils/invite-codes.ts
@@ -1,149 +1,44 @@
-import { InviteCodesApi, Configuration } from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
+import { ApiError, getSupabaseClient, throwOnSupabaseError } from './supabase';
 
-export class ApiError extends Error {
-  status?: number;
-
-  constructor(message: string, status?: number) {
-    super(message);
-    this.name = 'ApiError';
-    this.status = status;
-  }
-}
-
-async function getApiClient(): Promise<InviteCodesApi> {
-  const { session } = await getSession();
-  const accessToken = session?.access_token;
-
-  if (!accessToken) {
-    throw new ApiError('No authentication token found. Please log in again.');
-  }
-
-  const config = new Configuration({
-    basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    accessToken: accessToken,
-  });
-
-  return new InviteCodesApi(config);
-}
+export { ApiError } from './supabase';
 
 export async function createInviteCode() {
-  try {
-    const api = await getApiClient();
-    const response = await api.inviteCodesControllerCreate({});
-    return (response as unknown as { data: any }).data;
-  } catch (error: any) {
-    console.error('API connection failed:', error);
-
-    if (error.response) {
-      const status = error.response.status;
-      let message = 'An error occurred while creating the invite code';
-
-      if (status === 401 || status === 403) {
-        message = 'You are not authorized to perform this action.';
-      } else if (status >= 500) {
-        message = 'Server error. Please try again later.';
-      } else if (error.response.data?.message) {
-        message = error.response.data.message;
-      }
-
-      throw new ApiError(message, status);
-    }
-
-    throw new ApiError(
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
-  }
+  const { data, error } = await getSupabaseClient().rpc('create_invite_code');
+  throwOnSupabaseError(error, 'Failed to create invite code');
+  return data;
 }
 
 export async function getInviteCodes() {
-  try {
-    const api = await getApiClient();
-    const response = await api.inviteCodesControllerFindAll();
-    return (response as unknown as { data: any[] }).data;
-  } catch (error: any) {
-    console.error('API connection failed:', error);
-
-    if (error.response) {
-      const status = error.response.status;
-      let message = 'An error occurred while fetching invite codes';
-
-      if (status === 401 || status === 403) {
-        message = 'You are not authorized to perform this action.';
-      } else if (status >= 500) {
-        message = 'Server error. Please try again later.';
-      } else if (error.response.data?.message) {
-        message = error.response.data.message;
-      }
-
-      throw new ApiError(message, status);
-    }
-
-    throw new ApiError(
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
-  }
+  const { data, error } = await getSupabaseClient()
+    .from('invite_codes')
+    .select('*')
+    .order('created_at', { ascending: false });
+  throwOnSupabaseError(error, 'Failed to fetch invite codes');
+  return data || [];
 }
 
 export async function validateInviteCode(code: string) {
-  try {
-    const config = new Configuration({
-      basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    });
-    const api = new InviteCodesApi(config);
-    const response = await api.inviteCodesControllerValidate({ code });
-    return (
-      response as unknown as { data: { valid: boolean; message?: string } }
-    ).data;
-  } catch (error: any) {
-    console.error('API connection failed:', error);
-
-    if (error.response) {
-      const errorData = error.response.data || {};
-      return {
-        valid: false,
-        message: errorData.message || 'Failed to validate invite code',
-      };
-    }
-
-    return {
-      valid: false,
-      message: 'Failed to validate invite code',
-    };
+  const { data, error } = await getSupabaseClient().rpc(
+    'validate_invite_code',
+    { p_code: code }
+  );
+  if (error) {
+    return { valid: false, message: 'Failed to validate invite code' };
   }
+  return {
+    valid: Boolean(data),
+    message: data ? undefined : 'Invite code is invalid or has already been used',
+  };
 }
 
 export async function consumeInviteCode(code: string) {
-  try {
-    const api = await getApiClient();
-    const response = await api.inviteCodesControllerConsume({ code });
-    return (response as unknown as { data: any }).data;
-  } catch (error: any) {
-    console.error('API connection failed:', error);
-
-    if (error.response) {
-      const status = error.response.status;
-      let message = 'An error occurred while consuming the invite code';
-
-      if (status === 400) {
-        message = error.response.data?.message || 'Invalid invite code state.';
-      } else if (status === 404) {
-        message = 'Invite code not found.';
-      } else if (status === 409) {
-        message = 'Invite code has already been used.';
-      } else if (status === 401) {
-        message = 'Unauthorized. Please log in again.';
-      } else if (status >= 500) {
-        message = 'Server error. Please try again later.';
-      } else if (error.response.data?.message) {
-        message = error.response.data.message;
-      }
-
-      throw new ApiError(message, status);
-    }
-
-    throw new ApiError(
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+  const { data, error } = await getSupabaseClient().rpc(
+    'redeem_invite_code',
+    { p_code: code }
+  );
+  throwOnSupabaseError(error, 'Failed to consume invite code');
+  if (!data) {
+    throw new ApiError('Invite code could not be consumed');
   }
+  return data;
 }

--- a/apps/web/src/utils/schedules.ts
+++ b/apps/web/src/utils/schedules.ts
@@ -1,0 +1,17 @@
+import { Schedule } from '@/types/schedule';
+import { getSupabaseClient, throwOnSupabaseError } from './supabase';
+
+export async function createVaccinationSchedule(
+  exposureId: string,
+  startDate?: string
+): Promise<Schedule> {
+  const { data, error } = await getSupabaseClient().rpc(
+    'create_vaccination_schedule',
+    {
+      p_exposure_id: exposureId,
+      p_start_date: startDate ? startDate.slice(0, 10) : undefined,
+    }
+  );
+  throwOnSupabaseError(error, 'Failed to create vaccination schedule');
+  return data as Schedule;
+}

--- a/apps/web/src/utils/supabase.ts
+++ b/apps/web/src/utils/supabase.ts
@@ -1,0 +1,38 @@
+import { createClient } from '@/lib/supabase/client';
+
+export class ApiError extends Error {
+  status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+export function getSupabaseClient() {
+  return createClient();
+}
+
+export function throwOnSupabaseError(
+  error: { message: string; code?: string } | null,
+  fallback: string
+): never | void {
+  if (!error) {
+    return;
+  }
+
+  const status = error.code === 'PGRST116' ? 404 : undefined;
+  throw new ApiError(error.message || fallback, status);
+}
+
+export function response<T>(data: T) {
+  return {
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {},
+    request: {},
+  };
+}

--- a/apps/web/src/utils/test-api-connection.ts
+++ b/apps/web/src/utils/test-api-connection.ts
@@ -1,4 +1,4 @@
-import { AppApi, Configuration } from '@abc-admin/api-lib';
+import { createClient } from '@/lib/supabase/client';
 
 interface TestApiConnectionProps {
   setIsLoading: (isLoading: boolean) => void;
@@ -8,20 +8,19 @@ export const testApiConnection = async ({
   setIsLoading,
 }: TestApiConnectionProps) => {
   setIsLoading(true);
-
   try {
-    const config = new Configuration({
-      basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    });
-    const appApi = new AppApi(config);
-
-    const response = await appApi.appControllerGetData();
-    console.log('API Response:', response.data);
-    alert(`API connection successful!`);
+    const {
+      data: { user },
+      error,
+    } = await createClient().auth.getUser();
+    if (error || !user) {
+      throw error || new Error('No authenticated Supabase user');
+    }
+    alert('Supabase connection successful!');
   } catch (error) {
-    console.error('API connection failed:', error);
+    console.error('Supabase connection failed:', error);
     alert(
-      `API connection failed: ${
+      `Supabase connection failed: ${
         error instanceof Error ? error.message : 'Unknown error'
       }`
     );

--- a/apps/web/src/utils/update-patient.ts
+++ b/apps/web/src/utils/update-patient.ts
@@ -1,112 +1,46 @@
-import { Configuration, PatientsApi } from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
 import { EditablePatient, NewPatient } from '@/types/patient';
-import { ApiError } from './add-patient';
+import { getSupabaseClient, throwOnSupabaseError } from './supabase';
 
-// Create a shared API client
-async function getApiClient() {
-  const { session } = await getSession();
-  const accessToken = session?.access_token;
-
-  if (!accessToken) {
-    throw new ApiError('No authentication token found. Please log in again.');
-  }
-
-  return new PatientsApi(
-    new Configuration({
-      basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-      accessToken: accessToken,
-    })
+function patientFields(patient: Partial<NewPatient>) {
+  return Object.fromEntries(
+    Object.entries({
+      firstName: patient.firstName,
+      middleName: patient.middleName,
+      lastName: patient.lastName,
+      dateOfBirth: patient.dateOfBirth,
+      sex: patient.sex,
+      address: patient.address,
+      email: patient.email,
+    }).filter(([, value]) => value !== undefined)
   );
 }
-
-// Shared error handling function
-function handleApiError(error: any, context: string): never {
-  console.error(`API connection failed (${context}):`, error);
-
-  if (error.response) {
-    const status = error.response.status;
-    let message = `An error occurred while ${context}`;
-
-    if (status === 404) {
-      message = 'Patient not found.';
-    } else if (status === 400 && context.includes('update')) {
-      message = 'Invalid input data. Please check your form and try again.';
-    } else if (status === 401 || status === 403) {
-      message = `You are not authorized to ${
-        context.includes('update') ? 'update' : 'view'
-      } this patient.`;
-    } else if (status >= 500) {
-      message = 'Server error. Please try again later.';
-    }
-
-    throw new ApiError(message, status);
-  }
-
-  throw new ApiError(
-    error instanceof Error ? error.message : 'Unknown error occurred'
-  );
-}
-
-// Adapter function to convert Partial<NewPatient> to CreatePatientDto
-// Only includes patient metadata fields (exposure fields should be updated separately)
-const adaptToUpdatePatientDto = (patient: Partial<NewPatient>): any => {
-  // Only include patient metadata fields
-  const adaptedPatient: any = {};
-
-  if (patient.firstName !== undefined)
-    adaptedPatient.firstName = patient.firstName;
-  if (patient.middleName !== undefined)
-    adaptedPatient.middleName = patient.middleName;
-  if (patient.lastName !== undefined)
-    adaptedPatient.lastName = patient.lastName;
-  if (patient.dateOfBirth !== undefined)
-    adaptedPatient.dateOfBirth = patient.dateOfBirth;
-  if (patient.sex !== undefined) adaptedPatient.sex = patient.sex;
-  if (patient.address !== undefined) adaptedPatient.address = patient.address;
-  if (patient.email !== undefined) adaptedPatient.email = patient.email;
-
-  return adaptedPatient;
-};
 
 export const getPatient = async (
   patientId: string
 ): Promise<EditablePatient> => {
-  try {
-    const patientsApi = await getApiClient();
-    const response = await patientsApi.patientsControllerFindOne(patientId);
-    return (response as any).data as EditablePatient;
-  } catch (error: any) {
-    handleApiError(error, 'retrieving the patient');
-  }
+  const { data, error } = await getSupabaseClient()
+    .from('patients')
+    .select('*')
+    .eq('id', patientId)
+    .single();
+  throwOnSupabaseError(error, 'Patient not found');
+  return data as EditablePatient;
 };
 
 export const updatePatient = async (
   patientId: string,
   updatedPatient: Partial<NewPatient>
 ): Promise<EditablePatient> => {
-  try {
-    const patientsApi = await getApiClient();
-    const adaptedPatient = adaptToUpdatePatientDto(updatedPatient);
-    const response = await patientsApi.patientsControllerUpdate(
-      patientId,
-      adaptedPatient
-    );
-    return (response as any).data as EditablePatient;
-  } catch (error: any) {
-    handleApiError(error, 'updating the patient');
-  }
+  const { data, error } = await getSupabaseClient()
+    .from('patients')
+    .update(patientFields(updatedPatient))
+    .eq('id', patientId)
+    .select()
+    .single();
+  throwOnSupabaseError(error, 'Failed to update patient');
+  return data as EditablePatient;
 };
 
-export const updatePatientAntiTetanus = async (
-  patientId: string,
-  administered: boolean,
-  date?: Date
-): Promise<EditablePatient> => {
-  // Note: Anti-tetanus is now part of exposure, not patient
-  // This function should be updated to update the exposure instead
-  // For now, this is a placeholder that will need to be refactored
-  throw new Error(
-    'updatePatientAntiTetanus should be updated to update exposure instead of patient'
-  );
-};
+export async function updatePatientAntiTetanus(): Promise<never> {
+  throw new Error('Anti-tetanus is managed on the patient exposure.');
+}

--- a/apps/web/src/utils/update-vaccination.ts
+++ b/apps/web/src/utils/update-vaccination.ts
@@ -1,52 +1,14 @@
-import { Configuration, SchedulesApi } from '@abc-admin/api-lib';
-import { getSession } from '@/lib/auth/client';
 import { VaccinationDay } from '@/types/schedule';
-import { ApiError } from './add-patient';
+import { getSupabaseClient, throwOnSupabaseError } from './supabase';
 
 export const updateVaccination = async (
-  patientId: string,
+  _patientId: string,
   scheduleId: string,
   vaccinationDay: VaccinationDay
 ): Promise<void> => {
-  const { session } = await getSession();
-  const accessToken = session?.access_token;
-
-  if (!accessToken) {
-    throw new ApiError(
-      'No authentication token found. Please log in again.',
-      401
-    );
-  }
-
-  const config = new Configuration({
-    basePath: process.env.NEXT_PUBLIC_BACKEND_URL,
-    accessToken: accessToken,
+  const { error } = await getSupabaseClient().rpc('toggle_vaccination', {
+    p_schedule_id: scheduleId,
+    p_day: vaccinationDay,
   });
-
-  try {
-    const schedulesApi = new SchedulesApi(config);
-    await schedulesApi.schedulesControllerUpdateVaccination(scheduleId, {
-      patientId,
-      day: vaccinationDay,
-    });
-  } catch (error: any) {
-    console.error('API connection failed:', error);
-    if (error.response) {
-      const status = error.response.status;
-      let message = 'Failed to update vaccination schedule';
-      if (status === 404) {
-        message = 'Schedule not found.';
-      } else if (status === 400) {
-        message = 'Invalid vaccination data.';
-      } else if (status === 401 || status === 403) {
-        message = 'You are not authorized to perform this action.';
-      } else if (status >= 500) {
-        message = 'Server error. Please try again later.';
-      }
-      throw new ApiError(message, status);
-    }
-    throw new ApiError(
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
-  }
+  throwOnSupabaseError(error, 'Failed to update vaccination schedule');
 };

--- a/apps/web/src/utils/vaccination-updater.ts
+++ b/apps/web/src/utils/vaccination-updater.ts
@@ -27,12 +27,7 @@ export async function updateVaccinationStatus({
     const vaccinationDay = mapDayToVaccinationDay(day);
 
     // Update vaccination in the backend
-    await updateVaccination({
-      setIsLoading: setIsSaving,
-      patientId,
-      vaccinationDay,
-      scheduleId: scheduleData.id,
-    });
+    await updateVaccination(patientId, scheduleData.id, vaccinationDay);
 
     // Update local state
     const updatedVaccinations = scheduleData.vaccinations.map((vaccination) => {

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,30 @@
+# Supabase-native backend
+
+The application database already runs on Supabase. The migration in this folder
+moves API authorization into Row Level Security (RLS) and moves transactional
+workflows into Postgres RPC functions:
+
+- `create_invite_code` and `redeem_invite_code`
+- `create_vaccination_schedule`
+- `toggle_vaccination`
+- `patient_summary`
+- `list_patient_summaries`
+
+The web app should call table queries and these RPC functions through
+`@supabase/supabase-js`. Keep the Nest API deployed until the frontend has been
+cut over and validated.
+
+## Deployment
+
+Do not apply this migration from the Supabase Dashboard. Authenticate and link
+the CLI to the existing project, inspect the pending change, then push it:
+
+```sh
+supabase login
+supabase link
+supabase db push --dry-run
+supabase db push
+```
+
+The RLS policies change the access model for browser clients. Validate with a
+non-production Supabase project before applying it to production.

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -10,9 +10,11 @@ workflows into Postgres RPC functions:
 - `patient_summary`
 - `list_patient_summaries`
 
-The web app should call table queries and these RPC functions through
-`@supabase/supabase-js`. Keep the Nest API deployed until the frontend has been
-cut over and validated.
+The web app calls table queries and these RPC functions through
+`@supabase/supabase-js`. Configure `NEXT_PUBLIC_SUPABASE_URL` and
+`NEXT_PUBLIC_SUPABASE_ANON_KEY` for the web deployment before enabling the
+cutover. Keep the Nest API deployed until the migration is applied and the
+Supabase-backed frontend has been validated.
 
 ## Deployment
 

--- a/supabase/migrations/20260716000000_supabase_native_backend.sql
+++ b/supabase/migrations/20260716000000_supabase_native_backend.sql
@@ -2,8 +2,6 @@
 -- This migration is additive: the Nest API can continue to use the same tables
 -- during the frontend cutover, while browser clients use RLS and RPCs directly.
 
-begin;
-
 create index if not exists patients_managed_by_id_idx
   on public.patients ("managedById");
 create index if not exists exposures_patient_id_idx
@@ -298,8 +296,8 @@ begin
     raise exception 'Unsupported vaccination day';
   end if;
 
-  select s, e."animalStatus"::text = 'alive'
-  into v_schedule, v_animal_alive
+  select s.*
+  into v_schedule
   from public.schedules s
   join public.exposures e on e.id = s."exposureId"
   join public.patients p on p.id = e."patientId"
@@ -310,6 +308,11 @@ begin
   if not found then
     raise exception 'Schedule not found' using errcode = 'P0002';
   end if;
+
+  select "animalStatus"::text = 'alive'
+  into v_animal_alive
+  from public.exposures
+  where id = v_schedule."exposureId";
 
   if p_day = 0 then
     v_schedule."day0Completed" := not v_schedule."day0Completed";
@@ -454,5 +457,3 @@ grant execute on function public.toggle_vaccination(uuid, integer) to authentica
 grant execute on function public.patient_summary(uuid) to authenticated;
 grant execute on function public.list_patient_summaries(integer, integer) to authenticated;
 grant execute on function public.validate_invite_code(uuid) to anon, authenticated;
-
-commit;

--- a/supabase/migrations/20260716000000_supabase_native_backend.sql
+++ b/supabase/migrations/20260716000000_supabase_native_backend.sql
@@ -1,0 +1,458 @@
+-- Move authorization and transactional clinic workflows into Supabase.
+-- This migration is additive: the Nest API can continue to use the same tables
+-- during the frontend cutover, while browser clients use RLS and RPCs directly.
+
+begin;
+
+create index if not exists patients_managed_by_id_idx
+  on public.patients ("managedById");
+create index if not exists exposures_patient_id_idx
+  on public.exposures ("patientId");
+create index if not exists schedules_exposure_id_idx
+  on public.schedules ("exposureId");
+
+-- SECURITY DEFINER helpers are deliberately narrow and use the authenticated
+-- Supabase user ID rather than mutable user metadata.
+create or replace function public.is_active_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.users
+    where id = auth.uid()
+      and "isActive" = true
+      and role::text = 'ADMIN'
+  );
+$$;
+
+create or replace function public.owns_patient(p_patient_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.patients
+    where id = p_patient_id
+      and "managedById" = auth.uid()
+  );
+$$;
+
+create or replace function public.owns_exposure(p_exposure_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.exposures e
+    join public.patients p on p.id = e."patientId"
+    where e.id = p_exposure_id
+      and p."managedById" = auth.uid()
+  );
+$$;
+
+-- The client never chooses the manager of a patient record.
+create or replace function public.assign_patient_manager()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Authentication is required';
+  end if;
+
+  if tg_op = 'INSERT' then
+    if new."managedById" is null then
+      new."managedById" := auth.uid();
+    elsif new."managedById" <> auth.uid() then
+      raise exception 'Patients can only be assigned to the current user';
+    end if;
+  elsif new."managedById" is distinct from old."managedById" then
+    raise exception 'Changing a patient manager is not allowed';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists set_patient_manager on public.patients;
+create trigger set_patient_manager
+before insert or update on public.patients
+for each row execute function public.assign_patient_manager();
+
+alter table public.users enable row level security;
+alter table public.patients enable row level security;
+alter table public.exposures enable row level security;
+alter table public.schedules enable row level security;
+alter table public.invite_codes enable row level security;
+
+drop policy if exists users_admin_read on public.users;
+create policy users_admin_read on public.users
+for select to authenticated
+using (public.is_active_admin());
+
+drop policy if exists patients_owner_read on public.patients;
+drop policy if exists patients_owner_insert on public.patients;
+drop policy if exists patients_owner_update on public.patients;
+drop policy if exists patients_owner_delete on public.patients;
+create policy patients_owner_read on public.patients
+for select to authenticated
+using ("managedById" = auth.uid());
+create policy patients_owner_insert on public.patients
+for insert to authenticated
+with check ("managedById" = auth.uid());
+create policy patients_owner_update on public.patients
+for update to authenticated
+using ("managedById" = auth.uid())
+with check ("managedById" = auth.uid());
+create policy patients_owner_delete on public.patients
+for delete to authenticated
+using ("managedById" = auth.uid());
+
+drop policy if exists exposures_owner_read on public.exposures;
+drop policy if exists exposures_owner_insert on public.exposures;
+drop policy if exists exposures_owner_update on public.exposures;
+drop policy if exists exposures_owner_delete on public.exposures;
+create policy exposures_owner_read on public.exposures
+for select to authenticated
+using (public.owns_patient("patientId"));
+create policy exposures_owner_insert on public.exposures
+for insert to authenticated
+with check (public.owns_patient("patientId"));
+create policy exposures_owner_update on public.exposures
+for update to authenticated
+using (public.owns_patient("patientId"))
+with check (public.owns_patient("patientId"));
+create policy exposures_owner_delete on public.exposures
+for delete to authenticated
+using (public.owns_patient("patientId"));
+
+drop policy if exists schedules_owner_read on public.schedules;
+drop policy if exists schedules_owner_insert on public.schedules;
+drop policy if exists schedules_owner_update on public.schedules;
+drop policy if exists schedules_owner_delete on public.schedules;
+create policy schedules_owner_read on public.schedules
+for select to authenticated
+using (public.owns_exposure("exposureId"));
+create policy schedules_owner_insert on public.schedules
+for insert to authenticated
+with check (public.owns_exposure("exposureId"));
+create policy schedules_owner_update on public.schedules
+for update to authenticated
+using (public.owns_exposure("exposureId"))
+with check (public.owns_exposure("exposureId"));
+create policy schedules_owner_delete on public.schedules
+for delete to authenticated
+using (public.owns_exposure("exposureId"));
+
+drop policy if exists invite_codes_admin_read on public.invite_codes;
+create policy invite_codes_admin_read on public.invite_codes
+for select to authenticated
+using (public.is_active_admin());
+
+-- Invite workflow: only an existing administrator can create an invite, and a
+-- signed-in Supabase user becomes a local administrator only by redeeming one.
+create or replace function public.create_invite_code()
+returns public.invite_codes
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_invite public.invite_codes;
+begin
+  if not public.is_active_admin() then
+    raise exception 'Administrator access is required' using errcode = '42501';
+  end if;
+
+  insert into public.invite_codes (code, created_by, is_active)
+  values (uuid_generate_v4(), auth.uid(), true)
+  returning * into v_invite;
+
+  return v_invite;
+end;
+$$;
+
+create or replace function public.validate_invite_code(p_code uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.invite_codes
+    where code = p_code
+      and is_active = true
+      and consumed_by is null
+  );
+$$;
+
+create or replace function public.redeem_invite_code(p_code uuid)
+returns public.invite_codes
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_invite public.invite_codes;
+  v_email text;
+begin
+  if auth.uid() is null then
+    raise exception 'Authentication is required' using errcode = '28000';
+  end if;
+
+  select * into v_invite
+  from public.invite_codes
+  where code = p_code
+  for update;
+
+  if not found then
+    raise exception 'Invite code not found' using errcode = 'P0002';
+  end if;
+  if not v_invite.is_active or v_invite.consumed_by is not null then
+    raise exception 'Invite code is no longer valid' using errcode = '23505';
+  end if;
+
+  select email into v_email from auth.users where id = auth.uid();
+  if v_email is null then
+    raise exception 'Authenticated user has no email address';
+  end if;
+
+  insert into public.users (id, email, role, "isActive")
+  values (auth.uid(), v_email, 'ADMIN'::public.users_role_enum, true)
+  on conflict (id) do nothing;
+
+  update public.invite_codes
+  set consumed_by = auth.uid(),
+      consumed_at = now(),
+      is_active = false
+  where id = v_invite.id
+  returning * into v_invite;
+
+  return v_invite;
+end;
+$$;
+
+-- Schedule creation and vaccination updates remain transactional, but no longer
+-- need a separate application server.
+create or replace function public.create_vaccination_schedule(
+  p_exposure_id uuid,
+  p_start_date date default current_date
+)
+returns public.schedules
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_schedule public.schedules;
+begin
+  if not public.owns_exposure(p_exposure_id) then
+    raise exception 'Exposure not found' using errcode = 'P0002';
+  end if;
+
+  insert into public.schedules (
+    "exposureId", status, "day0Date", "day3Date", "day7Date", "day28Date"
+  )
+  values (
+    p_exposure_id,
+    'in_progress'::public.schedules_status_enum,
+    p_start_date,
+    p_start_date + 3,
+    p_start_date + 7,
+    p_start_date + 28
+  )
+  returning * into v_schedule;
+
+  return v_schedule;
+end;
+$$;
+
+create or replace function public.toggle_vaccination(
+  p_schedule_id uuid,
+  p_day integer
+)
+returns public.schedules
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_schedule public.schedules;
+  v_animal_alive boolean;
+begin
+  if p_day not in (0, 3, 7, 28) then
+    raise exception 'Unsupported vaccination day';
+  end if;
+
+  select s, e."animalStatus"::text = 'alive'
+  into v_schedule, v_animal_alive
+  from public.schedules s
+  join public.exposures e on e.id = s."exposureId"
+  join public.patients p on p.id = e."patientId"
+  where s.id = p_schedule_id
+    and p."managedById" = auth.uid()
+  for update of s;
+
+  if not found then
+    raise exception 'Schedule not found' using errcode = 'P0002';
+  end if;
+
+  if p_day = 0 then
+    v_schedule."day0Completed" := not v_schedule."day0Completed";
+    v_schedule."day0CompletedAt" := case when v_schedule."day0Completed" then now() else null end;
+  elsif p_day = 3 then
+    v_schedule."day3Completed" := not v_schedule."day3Completed";
+    v_schedule."day3CompletedAt" := case when v_schedule."day3Completed" then now() else null end;
+  elsif p_day = 7 then
+    v_schedule."day7Completed" := not v_schedule."day7Completed";
+    v_schedule."day7CompletedAt" := case when v_schedule."day7Completed" then now() else null end;
+  else
+    v_schedule."day28Completed" := not v_schedule."day28Completed";
+    v_schedule."day28CompletedAt" := case when v_schedule."day28Completed" then now() else null end;
+  end if;
+
+  v_schedule.status := case
+    when v_schedule."day0Completed"
+      and v_schedule."day3Completed"
+      and v_schedule."day7Completed"
+      and (v_animal_alive or v_schedule."day28Completed")
+      then 'completed'::public.schedules_status_enum
+    else 'in_progress'::public.schedules_status_enum
+  end;
+  v_schedule."updatedAt" := now();
+
+  update public.schedules
+  set status = v_schedule.status,
+      "day0Completed" = v_schedule."day0Completed",
+      "day3Completed" = v_schedule."day3Completed",
+      "day7Completed" = v_schedule."day7Completed",
+      "day28Completed" = v_schedule."day28Completed",
+      "day0CompletedAt" = v_schedule."day0CompletedAt",
+      "day3CompletedAt" = v_schedule."day3CompletedAt",
+      "day7CompletedAt" = v_schedule."day7CompletedAt",
+      "day28CompletedAt" = v_schedule."day28CompletedAt",
+      "updatedAt" = v_schedule."updatedAt"
+  where id = p_schedule_id
+  returning * into v_schedule;
+
+  return v_schedule;
+end;
+$$;
+
+-- Read models replace the API's N+1 patient/schedule queries.
+create or replace function public.patient_summary(p_patient_id uuid)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select jsonb_build_object(
+    'id', p.id,
+    'firstName', p."firstName",
+    'middleName', coalesce(p."middleName", ''),
+    'lastName', p."lastName",
+    'dateOfBirth', p."dateOfBirth",
+    'animalStatus', coalesce(e."animalStatus"::text, 'unknown'),
+    'antiTetanusGiven', coalesce(e."antiTetanusGiven", false),
+    'dateOfAntiTetanus', e."dateOfAntiTetanus",
+    'dateRegistered', p."createdAt",
+    'scheduleStatus', s.status,
+    'nextVaccinationDate', case
+      when s."day0Completed" = false then s."day0Date"
+      when s."day3Completed" = false then s."day3Date"
+      when s."day7Completed" = false then s."day7Date"
+      when s."day28Completed" = false then s."day28Date"
+      else null
+    end,
+    'nextVaccinationDay', case
+      when s."day0Completed" = false then 'Day 0'
+      when s."day3Completed" = false then 'Day 3'
+      when s."day7Completed" = false then 'Day 7'
+      when s."day28Completed" = false then 'Day 28'
+      else 'Completed'
+    end
+  )
+  from public.patients p
+  left join lateral (
+    select * from public.exposures
+    where "patientId" = p.id
+    order by "createdAt" desc
+    limit 1
+  ) e on true
+  left join lateral (
+    select s.* from public.schedules s
+    join public.exposures se on se.id = s."exposureId"
+    where se."patientId" = p.id
+    order by (s.status::text = 'in_progress') desc, s."createdAt" desc
+    limit 1
+  ) s on true
+  where p.id = p_patient_id
+    and p."managedById" = auth.uid();
+$$;
+
+create or replace function public.list_patient_summaries(
+  p_page integer default 1,
+  p_page_size integer default 10
+)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with owned_patients as (
+    select id, "createdAt"
+    from public.patients
+    where "managedById" = auth.uid()
+  ), paged_patients as (
+    select id, "createdAt"
+    from owned_patients
+    order by "createdAt" desc
+    limit greatest(p_page_size, 1)
+    offset greatest(p_page - 1, 0) * greatest(p_page_size, 1)
+  )
+  select jsonb_build_object(
+    'patients', coalesce(
+      jsonb_agg(public.patient_summary(id) order by "createdAt" desc),
+      '[]'::jsonb
+    ),
+    'total', (select count(*) from owned_patients)
+  )
+  from paged_patients;
+$$;
+
+revoke all on function public.is_active_admin() from public;
+revoke all on function public.owns_patient(uuid) from public;
+revoke all on function public.owns_exposure(uuid) from public;
+revoke all on function public.assign_patient_manager() from public;
+revoke all on function public.create_invite_code() from public;
+revoke all on function public.redeem_invite_code(uuid) from public;
+revoke all on function public.create_vaccination_schedule(uuid, date) from public;
+revoke all on function public.toggle_vaccination(uuid, integer) from public;
+revoke all on function public.patient_summary(uuid) from public;
+revoke all on function public.list_patient_summaries(integer, integer) from public;
+
+grant execute on function public.create_invite_code() to authenticated;
+grant execute on function public.redeem_invite_code(uuid) to authenticated;
+grant execute on function public.create_vaccination_schedule(uuid, date) to authenticated;
+grant execute on function public.toggle_vaccination(uuid, integer) to authenticated;
+grant execute on function public.patient_summary(uuid) to authenticated;
+grant execute on function public.list_patient_summaries(integer, integer) to authenticated;
+grant execute on function public.validate_invite_code(uuid) to anon, authenticated;
+
+commit;


### PR DESCRIPTION
## Summary
- add a Supabase migration for Row Level Security across clinic data
- move invite redemption, vaccination scheduling, and patient summaries into Postgres RPC functions
- replace the web app's generated Nest API client with direct Supabase table and RPC calls
- document deployment configuration and the staged cutover

## Why
The Render API adds an unnecessary hop between the web app and the Supabase database. This changes the web data layer to use Supabase directly while keeping the Nest API available only as a rollback option.

## Validation
- web TypeScript check
- targeted Supabase data-layer lint
- live table schema inspected before authoring the RLS migration

## Required deployment order
1. Apply the Supabase migration after a dry run.
2. Set `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` on the web deployment.
3. Validate authenticated clinic workflows, then retire Render.