### PR TITLE
Fix Vercel web build

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -45,9 +45,6 @@
   "references": [
     {
       "path": "../../libs/enums"
-    },
-    {
-      "path": "../../libs/api-lib"
     }
   ]
 }


### PR DESCRIPTION
## What changed

Removed the obsolete `libs/api-lib` TypeScript project reference from the web app.

## Why

The web app no longer imports that generated API library after the Supabase cutover. Nx detected the stale reference and stopped Vercel's production build with a workspace-out-of-sync error.

## Validation

- `NX_DAEMON=false npx nx sync:check`
- `NX_DAEMON=false npx nx build web`

Both pass locally. Merging this PR will trigger a new Vercel production deployment.
