### PR TITLE
Fix Vercel web build

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -45,9 +45,6 @@
   "references": [
     {
       "path": "../../libs/enums"
-    },
-    {
-      "path": "../../libs/api-lib"
     }
   ]
 }


### PR DESCRIPTION
## What changed

Removes the obsolete `libs/api-lib` TypeScript project reference from the web app.

## Why

The Supabase cutover removed this dependency, but Nx still treated the stale reference as a workspace synchronization error. This keeps the development branch buildable with the same Vercel/Nx configuration.

## Validation

The equivalent fix passed `NX_DAEMON=false npx nx sync:check` and `NX_DAEMON=false npx nx build web` on the main-targeted branch.
