### PR TITLE
Fix immediate sign-out state

### DIFF
--- a/apps/web/src/components/dialog/logout-confirmation.tsx
+++ b/apps/web/src/components/dialog/logout-confirmation.tsx
@@ -10,8 +10,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useRouter } from 'next/navigation';
-import { AppRoutes } from '@/constants/routes';
-import { logout } from '@/utils/login';
+import { useAuth } from '@/contexts/AuthContext';
 
 interface LogoutConfirmationProps {
   isOpen: boolean;
@@ -23,13 +22,14 @@ export function LogoutConfirmation({
   onOpenChange,
 }: LogoutConfirmationProps) {
   const router = useRouter();
+  const { logout } = useAuth();
 
   const handleLogout = async () => {
     try {
       await logout();
-      setTimeout(() => {
-        router.push(AppRoutes.HOME);
-      }, 0);
+      onOpenChange(false);
+      router.replace('/login');
+      router.refresh();
     } catch (error) {
       console.error('Failed to logout:', error);
     }

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   ReactNode,
 } from 'react';
-import { getSession } from '@/lib/auth/client';
+import { getSession, signOut as signOutServerSession } from '@/lib/auth/client';
 import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/client';
 
@@ -23,6 +23,7 @@ interface AuthContextType {
   user: User;
   isLoading: boolean;
   checkAuthStatus: () => Promise<void>;
+  logout: () => Promise<void>;
   supabaseUser: SupabaseUser | null;
   accessToken: string | null;
 }
@@ -38,6 +39,7 @@ const AuthContext = createContext<AuthContextType>({
   user: emptyUser,
   isLoading: true,
   checkAuthStatus: async () => {},
+  logout: async () => {},
   supabaseUser: null,
   accessToken: null,
 });
@@ -79,6 +81,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setAccessToken(null);
       setUser(emptyUser);
     } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const logout = async () => {
+    const { error } = await createClient().auth.signOut();
+    if (error) {
+      throw error;
+    }
+
+    try {
+      // Also clear the server-side Supabase cookies used by middleware.
+      await signOutServerSession();
+    } catch (error) {
+      // The browser session has already been cleared. Keep the UI signed out
+      // even if the cookie-clearing request is interrupted.
+      console.warn('Failed to clear the server-side session:', error);
+    } finally {
+      setSupabaseUser(null);
+      setAccessToken(null);
+      setUser(emptyUser);
       setIsLoading(false);
     }
   };
@@ -265,6 +288,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     user,
     isLoading,
     checkAuthStatus,
+    logout,
     supabaseUser,
     accessToken,
   };


### PR DESCRIPTION
## What changed

Backports the immediate sign-out fix to `development`.

## Why

Logout previously cleared only the server session. The browser Supabase session and React auth state stayed live until polling or refresh, so dashboard content remained visible.

## Validation

- `NX_DAEMON=false npx nx build web`
- Targeted ESLint checks for the modified auth context and logout dialog
